### PR TITLE
Remove old unsupported CUDA switch and replace ufloat

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ if(${CUDA_FOUND})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUDA_ACC")
     set(CUDA_NVCC_FLAGS
     ${CUDA_NVCC_FLAGS};
-    -O3 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61 -gencode arch=compute_20,code=sm_20
+    -O3 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61
     )
 
     cuda_add_executable(glimpse src/glimpse.cpp ${GLIMPSE_SRC} src/spg.cu src/spg.cpp)

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -53,8 +53,8 @@ spg::spg ( int npix, int nz, int nframes, const double *P, const float *l1_weigh
     d_w     = ( float ** ) malloc ( sizeof ( float * ) * nGPU );
 
     // Stride between coefficients processed by different GPUs
-    coeff_stride = ( ulong * ) malloc ( sizeof ( ulong ) * nGPU );
-    coeff_stride_pos = ( ulong * ) malloc ( sizeof ( ulong ) * nGPU );
+    coeff_stride = ( unsigned long * ) malloc ( sizeof ( unsigned long ) * nGPU );
+    coeff_stride_pos = ( unsigned long * ) malloc ( sizeof ( unsigned long ) * nGPU );
 
     // Memory allocation for all GPUs
     for ( int i = 0; i < nGPU; i++ ) {

--- a/src/spg.h
+++ b/src/spg.h
@@ -48,8 +48,8 @@ class spg
     int whichGPUs[MAX_GPUS];
     
     // Stride between coefficients proccessed by different GPUs
-    ulong * coeff_stride;
-    ulong * coeff_stride_pos;
+    unsigned long * coeff_stride;
+    unsigned long * coeff_stride_pos;
         
     // Device pointer arrays, storing  pointers for each device
     float ** d_x;


### PR DESCRIPTION
This should make it possible to compile Glimpse with CUDA 10.  Ref https://github.com/UCL/Glimpse/issues/1#issuecomment-486646120