### PR TITLE
Do not hardcode CUDA compute cabalities in the CMake file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,10 +110,10 @@ set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_FITS")
 if(${CUDA_FOUND})
     message("Compiling CUDA accelerated reconstruction code, with 3D support")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DCUDA_ACC")
-    set(CUDA_NVCC_FLAGS
-    ${CUDA_NVCC_FLAGS};
-    -O3 -gencode arch=compute_52,code=sm_52 -gencode arch=compute_61,code=sm_61
-    )
+    set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -O3")
+    foreach(CAPABILITY ${CUDA_COMPUTE_CAPABILITIES})
+      set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} -gencode arch=compute_${CAPABILITY},code=sm_${CAPABILITY}")
+    endforeach()
 
     cuda_add_executable(glimpse src/glimpse.cpp ${GLIMPSE_SRC} src/spg.cu src/spg.cpp)
     cuda_add_cufft_to_target(glimpse)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,15 @@ An example of *config3d.ini* can be found in the *example* directory.
 
 Reconstructing a 3D field is very computationally demanding, and using a GPU is higly recommended to speed up the reconstruction. If an installation of CUDA can be
 detected on your system, CMake will automatically compile GPU specific code to
-replace the CPU implementation.
+replace the CPU implementation.  If you want to compile for specific CUDA
+compute capabilities, list them as a semicolon-separated list in the
+`CUDA_COMPUTE_CAPABILITIES` CMake variable.  E.g., to compile for
+compute capabilities 3.7, 5.2, and 6.1 use
+```
+cmake -DCUDA_COMPUTE_CAPABILITIES="37;52;61" ..
+```
+Check the compute capability of your device, for example at
+<https://en.wikipedia.org/wiki/CUDA>.
 
 Glimpse uses peer-to-peer memory transfer between GPUs on a multi-gpu system. You
 may choose at runtime which GPUs to use in your system by providing the -g option:


### PR DESCRIPTION
It is quite annoying that CUDA compute capabilities are hardcoded in the CMake file.  Until https://github.com/UCL/Glimpse/pull/6 there was even an old compute capability that prevented us from compiling with recent CUDA versions.

This PR defines a CMake variable that can be used to specify the desired compute capabilities.