### PR TITLE
Do not hard code include paths for macOS in the CMake file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -59,10 +59,10 @@ install: true
 # Build steps
 script:
   - |
-    if [ "${CC}" = "/usr/local/opt/llvm/bin/clang" ]; then
-      export CXXFLAGS="-L$(brew --prefix libomp)/lib"
+    if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+      export LDFLAGS="-L$(brew --prefix libomp)/lib"
     fi
   - mkdir -p build && cd build
   - cmake ..
-  - make
+  - make VERBOSE=1
   - ./glimpse --version

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,14 +99,13 @@ configure_file(
 
 find_package(CUDA)
 
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}  -O3")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -O3")
 if("${CMAKE_CXX_COMPILER_ID}" STREQUAL "AppleClang")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -Xpreprocessor -fopenmp -lomp -I/usr/local/include -L/usr/local/lib -std=c++11")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fpermissive -Xpreprocessor -fopenmp -lomp -I/usr/local/include -L/usr/local/lib -std=c++11 -DDEBUG_FITS")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -Xpreprocessor -fopenmp -lomp -std=c++11")
 else()
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -fpermissive -fopenmp -std=c++11")
-  set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -fpermissive -fopenmp -std=c++11 -DDEBUG_FITS")
 endif()
+set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DDEBUG_FITS")
 
 if(${CUDA_FOUND})
     message("Compiling CUDA accelerated reconstruction code, with 3D support")

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Glimpse depends on the following software:
 * **NFFT** version 3.2 or later
 * **cfitsio** and **CCFits**
 * **GSL**
+* **OpenMP**
 * **CMake** version 2.8 or later
 
 These dependencies can easily be installed using a package manager:
@@ -45,6 +46,15 @@ Once the requirements are installed, Glimpse can be compiled by running the  fol
     $ make
   ```
 This will create a Glimpse executable in the build directory.
+
+#### macOS users
+
+If you installed OpenMP with HomeBrew, you will probably need to set the
+[`LDFLAGS`](https://cmake.org/cmake/help/latest/envvar/LDFLAGS.html) environment
+variable in the following way before running `cmake`:
+```
+LDFLAGS="-L$(brew --prefix libomp)/lib"
+```
 
 ## 2D Usage
 


### PR DESCRIPTION
With this change the CMake file doesn't have any hard coded reference to paths on the filesystem.  The downside is that macOS users may need to set an environment variable, but I don't think this is bad: this is how these things are supposed to work.  Anyway, I added a short section in the `README.md` to explain what to do.