### PR TITLE
Datacapture

### DIFF
--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -371,7 +371,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
         }
 
 #ifdef CUDA_ACC
-        prox->prox_l1(alpha_tmp,1000);
+        prox->prox_l1(alpha_tmp,1000, iter == niter/2);
 #else
         // TODO: Implement CPU prox operator
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -337,7 +337,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
             }
 
 #ifdef CUDA_ACC
-            prox->prox_pos(alpha_tmp, do_output = (iter == niter/2));
+            prox->prox_pos(alpha_tmp, 10000, iter == niter/2);
 #else
 
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -337,7 +337,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
             }
 
 #ifdef CUDA_ACC
-            prox->prox_pos(alpha_tmp);
+            prox->prox_pos(alpha_tmp, do_output = (iter == niter/2));
 #else
 
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -562,18 +562,18 @@ void density_reconstruction::reconstruct()
     std::cout << "Running main iteration" << std::endl;
     run_main_iteration(nRecIter);
 
-    // Reweighted l1 loop
-    for (int i = 0; i < nreweights ; i++) {
-            f->update_covariance(delta);
-            compute_thresholds(nrandom / 2);
-            compute_weights();
-            run_main_iteration(nRecIter / 2);
-        }
+    // Reweighted l1 loop: don't run it
+//    for (int i = 0; i < nreweights ; i++) {
+//            f->update_covariance(delta);
+//            compute_thresholds(nrandom / 2);
+//            compute_weights();
+//            run_main_iteration(nRecIter / 2);
+//        }
 
-    std::cout  << "Starting debiasing " << std::endl;
-    // Final debiasing step
-    f->update_covariance(delta);
-    run_main_iteration(nRecIterDebias, true);
+//    std::cout  << "Starting debiasing " << std::endl;
+    // Final debiasing step: don't run this either
+//    f->update_covariance(delta);
+//    run_main_iteration(nRecIterDebias, true);
 }
 
 void density_reconstruction::compute_thresholds(int niter)

--- a/src/gpu_utils.h
+++ b/src/gpu_utils.h
@@ -44,7 +44,8 @@ extern int gpuCount;
 // Sets the number and IDs of GPUs to use
 static void setWhichGPUs(int count, int* whichGPUs){
     
-    gpuCount = count;
+//    gpuCount = count;
+    gpuCount = 1;
     int i = 0;
     for(i=0; i < count; i++){
         gpuIDs[i] = whichGPUs[i];

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -161,6 +161,10 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride_pos[i]*sizeof ( float ), &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
     }
 
+    if (do_output && CAPTURE_OUTPUT) {
+        write_u_x("i");
+    }
+
     for ( int i = 0; i < nGPU; i++ ) {
         // Select GPU
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
@@ -175,6 +179,10 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
 
         // Recover wavelet coefficients from device
         checkCudaErrors ( cudaMemcpy2DAsync ( &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), d_x[i], coeff_stride_pos[i]*sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+    }
+
+    if (do_output && CAPTURE_OUTPUT) {
+        write_u_x("o");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -201,10 +209,6 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         
     }
 
-    if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("i");
-    }
-
     for ( int i = 0; i < nGPU; i++ ) {
         // Select GPU
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
@@ -226,10 +230,6 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
 
         checkCudaErrors ( cudaDeviceSynchronize() );
         checkCudaErrors ( cudaPeekAtLastError() );
-    }
-
-    if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("o");
     }
 
     sdkStopTimer ( &timer );
@@ -336,5 +336,6 @@ void spg::write_u_x(char* suffix)
 
     delete[] alpha_rec;
     delete[] u_pos_rec;
+
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -342,9 +342,9 @@ void spg::write_pos_data(char* suffix)
 
     // Synchronously get the data. It will be needed immediately. Assumes ngpu == 1
     checkCudaErrors( cudaMemcpy2D(
-            alpha_rec, npix * npix * nframes * sizeof(float),
-            d_x[0], coeff_stride[0] * sizeof(float),
-            coeff_stride[0] * sizeof(float), nz,
+            alpha_rec, npix * npix * sizeof(float),
+            d_x[0], coeff_stride_pos[0] * sizeof(float),
+            coeff_stride_pos[0] * sizeof(float), nz,
             cudaMemcpyDeviceToHost
             ) );
 
@@ -359,7 +359,7 @@ void spg::write_pos_data(char* suffix)
     xname.append(suffix).append(extension);
 
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
-    long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
+    long alpha_bytes = sizeof(float) * npix * npix * nz;
 
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (u_pos_rec), u_buffer_bytes);

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -286,9 +286,18 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
 
+    std::cerr << "alpha size = " << npix * npix * nframes * sizeof ( float ) << ", x size = " << sizeof ( float ) * coeff_stride[0] * nz << std::endl;
+    std::cerr << "u_pos size = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
+
     std::string uname = "u";
     std::string xname = "x";
     std::string extension = ".dat";
+
+    // Get wavelet coefficients (cribbed from main iteration)
+
+
+
+
     uname.append(suffix).append(extension);
     xname.append(suffix).append(extension);
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -162,7 +162,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("i");
+        write_pos_data("i");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -182,7 +182,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("o");
+        write_pos_data("o");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -279,16 +279,9 @@ void spg::write_p_pp( )
     pstream.close();
 }
 
-void spg::write_u_x(char* suffix)
+void spg::write_pos_data(char* suffix)
 {
     std::ofstream uxstream;
-
-//    std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
-//    std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
-
-
-//    std::cerr << "alpha pitch = " << npix * npix * nframes * sizeof ( float ) << ", x pitch = " << sizeof ( float ) * coeff_stride[0] << std::endl;
-//    std::cerr << "u_pos pitch = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
 
     std::string uname = "u";
     std::string xname = "x";
@@ -313,18 +306,11 @@ void spg::write_u_x(char* suffix)
             cudaMemcpyDeviceToHost
         ) );
 
-
-
     uname.append(suffix).append(extension);
     xname.append(suffix).append(extension);
 
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
-    long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
-
     long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
-
-//    std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
-//    std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (u_pos_rec), u_buffer_bytes);

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -286,8 +286,8 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
 
-    std::cerr << "alpha size = " << npix * npix * nframes * sizeof ( float ) << ", x size = " << sizeof ( float ) * coeff_stride[0] * nz << std::endl;
-    std::cerr << "u_pos size = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
+    std::cerr << "alpha pitch = " << npix * npix * nframes * sizeof ( float ) << ", x pitch = " << sizeof ( float ) * coeff_stride[0] << std::endl;
+//    std::cerr << "u_pos pitch = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
 
     std::string uname = "u";
     std::string xname = "x";

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -238,7 +238,7 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_l1_data("i");
+        write_l1_data("o");
     }
 
     sdkStopTimer ( &timer );

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -283,14 +283,26 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
     std::cerr << "nz = " << nz << std::endl;
 
-    uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
-    uxstream.flush();
+    std::string uname = "u";
+    std::string xname = "x";
+    std::string extension = ".dat";
+    uname.append(suffix).append(extension);
+    xname.append(suffix).append(extension);
+
+    long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
+    long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
+
+    std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
+    std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
+
+    uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+//    uxstream.flush();
     uxstream.close();
 
-    uxstream.open(std::string("x").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_x[0]), sizeof(float) * coeff_stride[0] * nz);
-    uxstream.flush();
+    uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+//    uxstream.flush();
     uxstream.close();
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -261,6 +261,10 @@ void spg::write_config_file( )
     cfgstream << "nz=" << nz << std::endl;
 
     cfgstream.close();
+
+    std::cerr << "nz = " << nz << std::endl;
+    std::cerr << "npix = " << npix << std::endl;
+    std::cerr << "nframes = " << nframes << std::endl;
 }
 
 void spg::write_p_pp( )
@@ -281,7 +285,6 @@ void spg::write_u_x(char* suffix)
 
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
-    std::cerr << "nz = " << nz << std::endl;
 
     std::string uname = "u";
     std::string xname = "x";
@@ -292,36 +295,17 @@ void spg::write_u_x(char* suffix)
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
     long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
 
+    long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
+
     std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
     std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
-    uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
-
-    std::cerr << "Opening file" << std::endl;
-
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-
-    std::cerr << "Opened file, commencing write" << std::endl;
-
-    try {
-        uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
-    } catch (std::ofstream::failure e) {
-        std::cerr << "Exception writing to u file: " << e.what() << std::endl;
-    }
-
-    std::cerr << "Wrote data, closing file" << std::endl;
-//    uxstream.flush();
+    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
     uxstream.close();
 
-
-
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    try {
-        uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
-    } catch (std::ofstream::failure e) {
-        std::cerr << "Exception writing to x file: " << e.what() << std::endl;
-    }
-//    uxstream.flush();
+    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
     uxstream.close();
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -159,7 +159,12 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Copy wavelet coefficients to device
-        checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride_pos[i]*sizeof ( float ), &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                d_x[i], coeff_stride_pos[i]*sizeof ( float ),
+                &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ),
+                coeff_stride_pos[i]*sizeof ( float ), nz,
+                cudaMemcpyHostToDevice
+                ) );
     }
 
     if (do_output && CAPTURE_OUTPUT) {
@@ -179,7 +184,12 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Recover wavelet coefficients from device
-        checkCudaErrors ( cudaMemcpy2DAsync ( &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), d_x[i], coeff_stride_pos[i]*sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ),
+                d_x[i], coeff_stride_pos[i]*sizeof ( float ),
+                coeff_stride_pos[i]*sizeof ( float ), nz,
+                cudaMemcpyDeviceToHost
+                ) );
     }
 
     if (do_output && CAPTURE_OUTPUT) {
@@ -206,7 +216,12 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Copy wavelet coefficients to device
-        checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride[i]*sizeof ( float ), &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ), coeff_stride[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                d_x[i], coeff_stride[i]*sizeof ( float ),
+                &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ),
+                coeff_stride[i]*sizeof ( float ), nz,
+                cudaMemcpyHostToDevice
+                ) );
         
     }
 
@@ -227,7 +242,12 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Recover wavelet coefficients from device
-        checkCudaErrors ( cudaMemcpy2DAsync ( &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ), d_x[i], coeff_stride[i]*sizeof ( float ), coeff_stride[i] * sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ),
+                d_x[i], coeff_stride[i]*sizeof ( float ),
+                coeff_stride[i] * sizeof ( float ), nz,
+                cudaMemcpyDeviceToHost
+                ) );
     }
 
     for ( int i = 0; i < nGPU; i++ ) {

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -295,13 +295,23 @@ void spg::write_u_x(char* suffix)
     std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
     std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
+    uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
+
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+    try {
+        uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+    } catch (std::ofstream::failure e) {
+        std::cerr << "Exception writing to u file: " << e.what() << std::endl;
+    }
 //    uxstream.flush();
     uxstream.close();
 
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+    try {
+        uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+    } catch (std::ofstream::failure e) {
+        std::cerr << "Exception writing to x file: " << e.what() << std::endl;
+    }
 //    uxstream.flush();
     uxstream.close();
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -279,6 +279,10 @@ void spg::write_u_x(char* suffix)
 {
     std::ofstream uxstream;
 
+    std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
+    std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
+    std::cerr << "nz = " << nz << std::endl;
+
     uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
     uxstream.close();

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -119,8 +119,8 @@ spg::spg ( int npix, int nz, int nframes, const double *P, const float *l1_weigh
 
     if (CAPTURE_OUTPUT) {
         write_config_file();
-        write_l1_weights();
-        write_p_pp();
+        write_l1_weights("i");
+        write_p_pp("i");
     }
 
 
@@ -296,21 +296,31 @@ void spg::write_config_file( )
     std::cerr << "nframes = " << nframes << std::endl;
 }
 
-void spg::write_p_pp( )
+void spg::write_p_pp(char *suffix)
 {
+    std::string pname = "p_";
+    std::string ppname = "pp_";
+    std::string extension = ".dat";
+
+    pname.append(suffix).append(extension);
+    ppname.append(suffix).append(extension);
+
     std::ofstream pstream;
-    pstream.open("p.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    pstream.open(pname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     pstream.write(reinterpret_cast<char *> (p), sizeof(float) * nz * nz);
     pstream.close();
 
-    pstream.open("pp.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    pstream.open(ppname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     pstream.write(reinterpret_cast<char *> (pp), sizeof(float) * nz * nz);
     pstream.close();
 }
 
-void spg::write_l1_weights( )
+void spg::write_l1_weights(char *suffix)
 {
     std::ofstream wstream;
+
+    std::string wname = "w_";
+    std::string extension = ".dat";
 
     float* w_rec = new float[npix * npix * nframes * nz];
 
@@ -321,7 +331,9 @@ void spg::write_l1_weights( )
             cudaMemcpyDeviceToHost
             ) );
 
-    wstream.open("w.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    wname.append(suffix).append(extension);
+
+    wstream.open(wname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes * nz);
     wstream.close();
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -292,7 +292,7 @@ void spg::write_l1_weights( )
 {
     std::ofstream wstream;
 
-    float* w_rec = new float[npix * npix * nframes];
+    float* w_rec = new float[npix * npix * nframes * nz];
 
     checkCudaErrors( cudaMemcpy2D(
             w_rec, npix * npix * nframes * sizeof(float),
@@ -302,8 +302,10 @@ void spg::write_l1_weights( )
             ) );
 
     wstream.open("w.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes);
+    wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes * nz);
     wstream.close();
+
+    delete[] w_rec;
 }
 
 void spg::write_pos_data(char* suffix)
@@ -392,5 +394,8 @@ void spg::write_l1_data(char* suffix)
     l1stream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     l1stream.write(reinterpret_cast<char *> (u_rec), buffer_bytes);
     l1stream.close( );
+
+    delete[] alpha_rec;
+    delete[] u_rec;
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -297,14 +297,23 @@ void spg::write_u_x(char* suffix)
 
     uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
 
+    std::cerr << "Opening file" << std::endl;
+
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+
+    std::cerr << "Opened file, commencing write" << std::endl;
+
     try {
         uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
     } catch (std::ofstream::failure e) {
         std::cerr << "Exception writing to u file: " << e.what() << std::endl;
     }
+
+    std::cerr << "Wrote data, closing file" << std::endl;
 //    uxstream.flush();
     uxstream.close();
+
+
 
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     try {

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -137,7 +137,7 @@ spg::~spg()
     free ( pp );
 }
 
-void spg::prox_pos ( float *delta, int niter )
+void spg::prox_pos ( float *delta, int niter, bool do_output )
 {
     sdkResetTimer ( &timer );
     sdkStartTimer ( &timer );
@@ -176,7 +176,7 @@ void spg::prox_pos ( float *delta, int niter )
     std::cout << "Time spent for solving positivity spg " <<  sdkGetTimerValue ( &timer ) << std::endl;
 }
 
-void spg::prox_l1 ( float *alpha, int niter )
+void spg::prox_l1 ( float *alpha, int niter, bool do_output )
 {
     sdkResetTimer ( &timer );
     sdkStartTimer ( &timer );

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -281,10 +281,12 @@ void spg::write_u_x(char* suffix)
 
     uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
+    uxstream.flush();
     uxstream.close();
 
     uxstream.open(std::string("x").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_x[0]), sizeof(float) * coeff_stride[0] * nz);
+    uxstream.flush();
     uxstream.close();
 
 }

--- a/src/spg.h
+++ b/src/spg.h
@@ -95,7 +95,7 @@ public:
 private:
     void write_config_file();
     void write_p_pp();
-    void write_u_x(char* suffix);
+    void write_pos_data(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -91,6 +91,11 @@ public:
      */
     void update_weights(float *l1_weights);
     
+
+private:
+    void write_config_file();
+    void write_p_pp();
+    void write_u_x(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -78,13 +78,13 @@ public:
     /* Compute the proximity operator of the sparsity constraint.
      * 
      */
-    void prox_l1(float *alpha, int niter=10000);
+    void prox_l1(float *alpha, int niter=10000, bool do_output=false);
 
 
     /* Compute the proximity operator of the positivity constraint.
      *
      */
-    void prox_pos(float *delta, int niter=10000);
+    void prox_pos(float *delta, int niter=10000, bool do_output=false);
     
     /* Updates the l1 thresholds
      * 

--- a/src/spg.h
+++ b/src/spg.h
@@ -95,7 +95,9 @@ public:
 private:
     void write_config_file();
     void write_p_pp();
+    void write_l1_weights();
     void write_pos_data(char* suffix);
+    void write_l1_data(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -94,8 +94,8 @@ public:
 
 private:
     void write_config_file();
-    void write_p_pp();
-    void write_l1_weights();
+    void write_p_pp(char* suffix);
+    void write_l1_weights(char* suffix);
     void write_pos_data(char* suffix);
     void write_l1_data(char* suffix);
 };


### PR DESCRIPTION
A branch to capture the data before and after a single timestep of a Glimpse run. Dumps the data to fixed locations in the working directory. Uses a maximum of 1 GPU to simplify data transfer. The files come in a few sizes. Since this branch is fixed to run the reduced size example, the file sizes are fixed by the magnitudes of the array dimensions:
- `nx = ny = npix = 48` The size of the image in pixels.
- `nz = 16` The number of redshift sample.
- `nframes = 8` The number of wavelet components used to characterize the density.

These values give a few fixed array sizes:
- `np = nz × nz` Size of the **P** and **P**² matrices.
- `ncoeff = nx × ny × nz` Size of the arrays used in the positivity kernel.
- `nwavcoeff = nx × ny × nz × nframes` Size of the arrays used in the ℓ1 kernel.

The file prefices give the array the file holds.
- `delta_*.dat` contains the values of the independent variable used in the positivity kernel. Size = `ncoeff`
- `upos_*.dat` contains the values of the internal state of the positivity kernel. Size = `ncoeff`
- `alpha_*.dat` contains the values of the independent variable used in the ℓ1 kernel. Size = `nwavecoeff`
- `u_*.dat` contains the values of the internal state of the ℓ1 kernel. Size = `nwavecoeff`
- `p_*.dat` and `pp_*.dat` contain the values of the dictionary used in the ℓ1 kernel. Size = `np`
- `w.dat` holds the weights (target values) used in the ℓ1 kernel. Size = `nwavcoeff`

The file suffices give the input or output status of the contained data.
- `*_i.dat` contains the values at the start fot he call to the appropriate CUDA code
- `*_o.dat` conatins the values at the end of the call to the appropriate CUDA code