### PR TITLE
Singlestep3

### DIFF
--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -371,7 +371,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
         }
 
 #ifdef CUDA_ACC
-        prox->prox_l1(alpha_tmp,1000);
+        prox->prox_l1(alpha_tmp,1000, iter == niter/2);
 #else
         // TODO: Implement CPU prox operator
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -40,7 +40,7 @@
 
 #include "density_reconstruction.h"
 
-void read_float_data(char *filename, float *array, int size);
+void read_float_data(std::string filename, float *array, int size);
 
 using namespace std;
 
@@ -342,39 +342,40 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
                 alpha_tmp[ind] = delta_tmp[ind][0] * fftFactor;
             }
 
-        // Read the 'before' data files for the positivity step
-        read_float_data("delta_i.dat", alpha_tmp, ncoeff);
-        float* h_u_pos = new float[npix * npix * nlp];
-        read_float_data("upos_i.data", h_u_pos, npix * npix * nlp);
+            // Read the 'before' data files for the positivity step
+            std::string dot_ext = ".dat";
+            read_float_data(std::string("delta_i") + dot_ext, alpha_tmp, ncoeff);
+            float* h_u_pos = new float[npix * npix * nlp];
+            read_float_data(std::string("upos_i") + dot_ext, h_u_pos, npix * npix * nlp);
 
 #ifdef CUDA_ACC
-        prox->inject_u_pos(h_u_pos);
-        prox->prox_pos(alpha_tmp, 10000, true);
-        prox->extract_u_pos(h_u_pos);
+            prox->inject_u_pos(h_u_pos);
+            prox->prox_pos(alpha_tmp, 10000, true);
+            prox->extract_u_pos(h_u_pos);
 
 #else
 
 #endif
         // Compare to the captured output data
-        float* alpha_after = new float[ncoeff];
-        read_float_data("delta_o.dat", alpha_after, ncoeff);
-        float* u_pos_after = new float[npix * npix * nlp];
-        read_float_data("upos_o.dat", u_pos_after, npix * npix * nlp);
+            float* alpha_after = new float[ncoeff];
+            read_float_data(std::string("delta_o") + dot_ext, alpha_after, ncoeff);
+            float* u_pos_after = new float[npix * npix * nlp];
+            read_float_data(std::string("upos_o") + dot_ext, u_pos_after, npix * npix * nlp);
 
        // compare_pos_data(alpha_tmp, alpha_after, h_u_pos, u_pos_after);
 
-        delete[] h_u_pos;
-        delete[] alpha_after;
-        delete[] u_pos_after;
+            delete[] h_u_pos;
+            delete[] alpha_after;
+            delete[] u_pos_after;
 
 
-        #pragma omp parallel for
-        for (long ind = 0; ind < ncoeff; ind++) {
+#pragma omp parallel for
+            for (long ind = 0; ind < ncoeff; ind++) {
                 delta_tmp[ind][0] = delta_tmp[ind][0] * fftFactor - alpha_tmp[ind];
                 delta_tmp[ind][1] = 0;
             }
         }else{
-            #pragma omp parallel for
+#pragma omp parallel for
             for (long ind = 0; ind < ncoeff; ind++) {
                 delta_tmp[ind][0] *= fftFactor;
                 delta_tmp[ind][1] = 0;
@@ -735,7 +736,7 @@ void density_reconstruction::get_density_map(double *d)
 }
 
 // Read size float values from filename into array
-void read_float_data(char *filename, float *array, int size)
+void read_float_data(std::string filename, float *array, int size)
 {
     std::ifstream instream;
     instream.open(filename, std::ios_base::binary | std::ios_base::in);

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -316,6 +316,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
 
     // single stepping
     niter = 1;
+    std::string dot_ext = ".dat";
 
     for (long iter = 0; iter < niter; iter++) {
         std::cout << "Iteration : " << iter << std::endl;
@@ -343,7 +344,6 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
             }
 
             // Read the 'before' data files for the positivity step
-            std::string dot_ext = ".dat";
             read_float_data(std::string("delta_i") + dot_ext, alpha_tmp, ncoeff);
             float* h_u_pos = new float[npix * npix * nlp];
             read_float_data(std::string("upos_i") + dot_ext, h_u_pos, npix * npix * nlp);
@@ -398,8 +398,14 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
           alpha_tmp[ind] = alpha_u[ind] + sig * alpha_tmp[ind];
         }
 
+        // Read in the single stepping data. Assume alpha is correct
+        float* h_u = new float[nwavcoeff];
+        read_float_data(std::string("u_i") + dot_ext, h_u, nwavcoeff);
+
 #ifdef CUDA_ACC
+        prox->inject_u(h_u);
         prox->prox_l1(alpha_tmp,1000, iter == niter/2);
+        prox->extract_u(h_u);
 #else
         // TODO: Implement CPU prox operator
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -337,7 +337,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
             }
 
 #ifdef CUDA_ACC
-            prox->prox_pos(alpha_tmp, do_output = (iter == niter/2));
+            prox->prox_pos(alpha_tmp, 10000, iter == niter/2);
 #else
 
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -311,6 +311,9 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
     double old_tk = 1.0;
     double tk;
 
+    // single stepping
+    niter = 1;
+
     for (long iter = 0; iter < niter; iter++) {
         std::cout << "Iteration : " << iter << std::endl;
 

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -337,7 +337,7 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
             }
 
 #ifdef CUDA_ACC
-            prox->prox_pos(alpha_tmp);
+            prox->prox_pos(alpha_tmp, do_output = (iter == niter/2));
 #else
 
 #endif

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -562,18 +562,18 @@ void density_reconstruction::reconstruct()
     std::cout << "Running main iteration" << std::endl;
     run_main_iteration(nRecIter);
 
-    // Reweighted l1 loop
-    for (int i = 0; i < nreweights ; i++) {
-            f->update_covariance(delta);
-            compute_thresholds(nrandom / 2);
-            compute_weights();
-            run_main_iteration(nRecIter / 2);
-        }
+    // Reweighted l1 loop: don't run it
+//    for (int i = 0; i < nreweights ; i++) {
+//            f->update_covariance(delta);
+//            compute_thresholds(nrandom / 2);
+//            compute_weights();
+//            run_main_iteration(nRecIter / 2);
+//        }
 
-    std::cout  << "Starting debiasing " << std::endl;
-    // Final debiasing step
-    f->update_covariance(delta);
-    run_main_iteration(nRecIterDebias, true);
+//    std::cout  << "Starting debiasing " << std::endl;
+    // Final debiasing step: don't run this either
+//    f->update_covariance(delta);
+//    run_main_iteration(nRecIterDebias, true);
 }
 
 void density_reconstruction::compute_thresholds(int niter)

--- a/src/density_reconstruction.cpp
+++ b/src/density_reconstruction.cpp
@@ -398,7 +398,8 @@ void density_reconstruction::run_main_iteration(long int niter, bool debias)
           alpha_tmp[ind] = alpha_u[ind] + sig * alpha_tmp[ind];
         }
 
-        // Read in the single stepping data. Assume alpha is correct
+        // Read in the single stepping data. Re-ingest alpha, as some arrays are not initialized
+        read_float_data(std::string("alpha_i") + dot_ext, alpha_tmp, nwavcoeff);
         float* h_u = new float[nwavcoeff];
         read_float_data(std::string("u_i") + dot_ext, h_u, nwavcoeff);
 

--- a/src/gpu_utils.h
+++ b/src/gpu_utils.h
@@ -44,7 +44,8 @@ extern int gpuCount;
 // Sets the number and IDs of GPUs to use
 static void setWhichGPUs(int count, int* whichGPUs){
     
-    gpuCount = count;
+//    gpuCount = count;
+    gpuCount = 1;
     int i = 0;
     for(i=0; i < count; i++){
         gpuIDs[i] = whichGPUs[i];

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -161,6 +161,10 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride_pos[i]*sizeof ( float ), &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
     }
 
+    if (do_output && CAPTURE_OUTPUT) {
+        write_u_x("i");
+    }
+
     for ( int i = 0; i < nGPU; i++ ) {
         // Select GPU
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
@@ -175,6 +179,10 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
 
         // Recover wavelet coefficients from device
         checkCudaErrors ( cudaMemcpy2DAsync ( &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), d_x[i], coeff_stride_pos[i]*sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+    }
+
+    if (do_output && CAPTURE_OUTPUT) {
+        write_u_x("o");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -201,10 +209,6 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         
     }
 
-    if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("i");
-    }
-
     for ( int i = 0; i < nGPU; i++ ) {
         // Select GPU
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
@@ -226,10 +230,6 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
 
         checkCudaErrors ( cudaDeviceSynchronize() );
         checkCudaErrors ( cudaPeekAtLastError() );
-    }
-
-    if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("o");
     }
 
     sdkStopTimer ( &timer );
@@ -336,5 +336,6 @@ void spg::write_u_x(char* suffix)
 
     delete[] alpha_rec;
     delete[] u_pos_rec;
+
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -119,8 +119,8 @@ spg::spg ( int npix, int nz, int nframes, const double *P, const float *l1_weigh
 
     if (CAPTURE_OUTPUT) {
         write_config_file();
-        write_l1_weights();
-        write_p_pp();
+        write_l1_weights("i");
+        write_p_pp("i");
     }
 
 
@@ -336,21 +336,31 @@ void spg::write_config_file( )
     std::cerr << "nframes = " << nframes << std::endl;
 }
 
-void spg::write_p_pp( )
+void spg::write_p_pp(char *suffix)
 {
+    std::string pname = "p_";
+    std::string ppname = "pp_";
+    std::string extension = ".dat";
+
+    pname.append(suffix).append(extension);
+    ppname.append(suffix).append(extension);
+
     std::ofstream pstream;
-    pstream.open("p.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    pstream.open(pname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     pstream.write(reinterpret_cast<char *> (p), sizeof(float) * nz * nz);
     pstream.close();
 
-    pstream.open("pp.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    pstream.open(ppname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     pstream.write(reinterpret_cast<char *> (pp), sizeof(float) * nz * nz);
     pstream.close();
 }
 
-void spg::write_l1_weights( )
+void spg::write_l1_weights(char *suffix)
 {
     std::ofstream wstream;
+
+    std::string wname = "w_";
+    std::string extension = ".dat";
 
     float* w_rec = new float[npix * npix * nframes * nz];
 
@@ -361,7 +371,9 @@ void spg::write_l1_weights( )
             cudaMemcpyDeviceToHost
             ) );
 
-    wstream.open("w.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    wname.append(suffix).append(extension);
+
+    wstream.open(wname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes * nz);
     wstream.close();
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -342,9 +342,9 @@ void spg::write_pos_data(char* suffix)
 
     // Synchronously get the data. It will be needed immediately. Assumes ngpu == 1
     checkCudaErrors( cudaMemcpy2D(
-            alpha_rec, npix * npix * nframes * sizeof(float),
-            d_x[0], coeff_stride[0] * sizeof(float),
-            coeff_stride[0] * sizeof(float), nz,
+            alpha_rec, npix * npix * sizeof(float),
+            d_x[0], coeff_stride_pos[0] * sizeof(float),
+            coeff_stride_pos[0] * sizeof(float), nz,
             cudaMemcpyDeviceToHost
             ) );
 
@@ -359,7 +359,7 @@ void spg::write_pos_data(char* suffix)
     xname.append(suffix).append(extension);
 
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
-    long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
+    long alpha_bytes = sizeof(float) * npix * npix * nz;
 
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (u_pos_rec), u_buffer_bytes);

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -286,9 +286,18 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
 
+    std::cerr << "alpha size = " << npix * npix * nframes * sizeof ( float ) << ", x size = " << sizeof ( float ) * coeff_stride[0] * nz << std::endl;
+    std::cerr << "u_pos size = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
+
     std::string uname = "u";
     std::string xname = "x";
     std::string extension = ".dat";
+
+    // Get wavelet coefficients (cribbed from main iteration)
+
+
+
+
     uname.append(suffix).append(extension);
     xname.append(suffix).append(extension);
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -162,7 +162,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("i");
+        write_pos_data("i");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -182,7 +182,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_u_x("o");
+        write_pos_data("o");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -279,16 +279,9 @@ void spg::write_p_pp( )
     pstream.close();
 }
 
-void spg::write_u_x(char* suffix)
+void spg::write_pos_data(char* suffix)
 {
     std::ofstream uxstream;
-
-//    std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
-//    std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
-
-
-//    std::cerr << "alpha pitch = " << npix * npix * nframes * sizeof ( float ) << ", x pitch = " << sizeof ( float ) * coeff_stride[0] << std::endl;
-//    std::cerr << "u_pos pitch = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
 
     std::string uname = "u";
     std::string xname = "x";
@@ -313,18 +306,11 @@ void spg::write_u_x(char* suffix)
             cudaMemcpyDeviceToHost
         ) );
 
-
-
     uname.append(suffix).append(extension);
     xname.append(suffix).append(extension);
 
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
-    long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
-
     long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
-
-//    std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
-//    std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (u_pos_rec), u_buffer_bytes);

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -286,8 +286,8 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
 
-    std::cerr << "alpha size = " << npix * npix * nframes * sizeof ( float ) << ", x size = " << sizeof ( float ) * coeff_stride[0] * nz << std::endl;
-    std::cerr << "u_pos size = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
+    std::cerr << "alpha pitch = " << npix * npix * nframes * sizeof ( float ) << ", x pitch = " << sizeof ( float ) * coeff_stride[0] << std::endl;
+//    std::cerr << "u_pos pitch = " << sizeof ( float ) * coeff_stride_pos[0] * nz;
 
     std::string uname = "u";
     std::string xname = "x";

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -168,7 +168,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_pos_data("i");
+        write_pos_data("w");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -193,7 +193,7 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_pos_data("o");
+        write_pos_data("c");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -226,7 +226,7 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_l1_data("i");
+        write_l1_data("w");
     }
 
     for ( int i = 0; i < nGPU; i++ ) {
@@ -258,7 +258,7 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_l1_data("o");
+        write_l1_data("c");
     }
 
     sdkStopTimer ( &timer );
@@ -278,6 +278,26 @@ void spg::update_weights ( float *l1_weights )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
         checkCudaErrors ( cudaDeviceSynchronize() );
     }
+}
+
+void spg::inject_u_pos ( float *h_u_pos )
+{
+    checkCudaErrors ( cudaMemcpy2DAsync (
+            d_u_pos[0], coeff_stride_pos[0] * sizeof(float),
+            h_u_pos, npix * npix * sizeof(float),
+            coeff_stride_pos[0] * sizeof(float), nz,
+            cudaMemcpyHostToDevice
+            ) );
+}
+
+void spg::extract_u_pos( float *h_u_pos )
+{
+    checkCudaErrors ( cudaMemcpy2D (
+        h_u_pos, npix * npix * sizeof(float),
+        d_u_pos[0], coeff_stride_pos[0] * sizeof(float),
+        coeff_stride_pos[0] * sizeof(float), nz,
+        cudaMemcpyDeviceToHost
+        ) );
 }
 
 void spg::write_config_file( )

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -300,6 +300,26 @@ void spg::extract_u_pos( float *h_u_pos )
         ) );
 }
 
+void spg::inject_u( float *h_u )
+{
+    checkCudaErrors ( cudaMemcpy2DAsync (
+            d_u[0], coeff_stride[0] * sizeof(float),
+            h_u, npix * npix * nframes * sizeof(float),
+            coeff_stride[0] * sizeof(float), nz,
+            cudaMemcpyHostToDevice
+            ) );
+}
+
+void spg::extract_u( float *h_u )
+{
+    checkCudaErrors ( cudaMemcpy2D (
+        h_u, npix * npix * nframes * sizeof(float),
+        d_u[0], coeff_stride[0] * sizeof(float),
+        coeff_stride[0] * sizeof(float), nz,
+        cudaMemcpyDeviceToHost
+        ) );
+}
+
 void spg::write_config_file( )
 {
     std::ofstream cfgstream;

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -238,7 +238,7 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
     }
 
     if (do_output && CAPTURE_OUTPUT) {
-        write_l1_data("i");
+        write_l1_data("o");
     }
 
     sdkStopTimer ( &timer );

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -283,14 +283,26 @@ void spg::write_u_x(char* suffix)
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
     std::cerr << "nz = " << nz << std::endl;
 
-    uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
-    uxstream.flush();
+    std::string uname = "u";
+    std::string xname = "x";
+    std::string extension = ".dat";
+    uname.append(suffix).append(extension);
+    xname.append(suffix).append(extension);
+
+    long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
+    long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
+
+    std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
+    std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
+
+    uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+//    uxstream.flush();
     uxstream.close();
 
-    uxstream.open(std::string("x").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_x[0]), sizeof(float) * coeff_stride[0] * nz);
-    uxstream.flush();
+    uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+//    uxstream.flush();
     uxstream.close();
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -261,6 +261,10 @@ void spg::write_config_file( )
     cfgstream << "nz=" << nz << std::endl;
 
     cfgstream.close();
+
+    std::cerr << "nz = " << nz << std::endl;
+    std::cerr << "npix = " << npix << std::endl;
+    std::cerr << "nframes = " << nframes << std::endl;
 }
 
 void spg::write_p_pp( )
@@ -281,7 +285,6 @@ void spg::write_u_x(char* suffix)
 
     std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
     std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
-    std::cerr << "nz = " << nz << std::endl;
 
     std::string uname = "u";
     std::string xname = "x";
@@ -292,36 +295,17 @@ void spg::write_u_x(char* suffix)
     long u_buffer_bytes = sizeof(float) * coeff_stride_pos[0] * nz;
     long x_buffer_bytes = sizeof(float) * coeff_stride[0] * nz;
 
+    long alpha_bytes = sizeof(float) * npix * npix * nframes * nz;
+
     std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
     std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
-    uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
-
-    std::cerr << "Opening file" << std::endl;
-
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-
-    std::cerr << "Opened file, commencing write" << std::endl;
-
-    try {
-        uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
-    } catch (std::ofstream::failure e) {
-        std::cerr << "Exception writing to u file: " << e.what() << std::endl;
-    }
-
-    std::cerr << "Wrote data, closing file" << std::endl;
-//    uxstream.flush();
+    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
     uxstream.close();
 
-
-
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    try {
-        uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
-    } catch (std::ofstream::failure e) {
-        std::cerr << "Exception writing to x file: " << e.what() << std::endl;
-    }
-//    uxstream.flush();
+    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
     uxstream.close();
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -159,7 +159,12 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Copy wavelet coefficients to device
-        checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride_pos[i]*sizeof ( float ), &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                d_x[i], coeff_stride_pos[i]*sizeof ( float ),
+                &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ),
+                coeff_stride_pos[i]*sizeof ( float ), nz,
+                cudaMemcpyHostToDevice
+                ) );
     }
 
     if (do_output && CAPTURE_OUTPUT) {
@@ -179,7 +184,12 @@ void spg::prox_pos ( float *delta, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Recover wavelet coefficients from device
-        checkCudaErrors ( cudaMemcpy2DAsync ( &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ), d_x[i], coeff_stride_pos[i]*sizeof ( float ), coeff_stride_pos[i]*sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                &delta[i * coeff_stride_pos[0]], npix * npix * sizeof ( float ),
+                d_x[i], coeff_stride_pos[i]*sizeof ( float ),
+                coeff_stride_pos[i]*sizeof ( float ), nz,
+                cudaMemcpyDeviceToHost
+                ) );
     }
 
     if (do_output && CAPTURE_OUTPUT) {
@@ -206,7 +216,12 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Copy wavelet coefficients to device
-        checkCudaErrors ( cudaMemcpy2DAsync ( d_x[i], coeff_stride[i]*sizeof ( float ), &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ), coeff_stride[i]*sizeof ( float ), nz, cudaMemcpyHostToDevice ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                d_x[i], coeff_stride[i]*sizeof ( float ),
+                &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ),
+                coeff_stride[i]*sizeof ( float ), nz,
+                cudaMemcpyHostToDevice
+                ) );
         
     }
 
@@ -227,7 +242,12 @@ void spg::prox_l1 ( float *alpha, int niter, bool do_output )
         checkCudaErrors ( cudaSetDevice ( whichGPUs[i] ) );
 
         // Recover wavelet coefficients from device
-        checkCudaErrors ( cudaMemcpy2DAsync ( &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ), d_x[i], coeff_stride[i]*sizeof ( float ), coeff_stride[i] * sizeof ( float ), nz, cudaMemcpyDeviceToHost ) );
+        checkCudaErrors ( cudaMemcpy2DAsync (
+                &alpha[i * coeff_stride[0]], npix * npix * nframes * sizeof ( float ),
+                d_x[i], coeff_stride[i]*sizeof ( float ),
+                coeff_stride[i] * sizeof ( float ), nz,
+                cudaMemcpyDeviceToHost
+                ) );
     }
 
     for ( int i = 0; i < nGPU; i++ ) {

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -295,13 +295,23 @@ void spg::write_u_x(char* suffix)
     std::cerr << "x buffer is " << u_buffer_bytes << std::endl;
     std::cerr << "y buffer is " << x_buffer_bytes << std::endl;
 
+    uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
+
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+    try {
+        uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
+    } catch (std::ofstream::failure e) {
+        std::cerr << "Exception writing to u file: " << e.what() << std::endl;
+    }
 //    uxstream.flush();
     uxstream.close();
 
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+    try {
+        uxstream.write(reinterpret_cast<char *> (d_x[0]), x_buffer_bytes);
+    } catch (std::ofstream::failure e) {
+        std::cerr << "Exception writing to x file: " << e.what() << std::endl;
+    }
 //    uxstream.flush();
     uxstream.close();
 

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -279,6 +279,10 @@ void spg::write_u_x(char* suffix)
 {
     std::ofstream uxstream;
 
+    std::cerr << "coeff_stride_pos[0] = " << coeff_stride_pos[0] << ", ";
+    std::cerr << "coeff_stride[0] = " << coeff_stride[0] << ", ";
+    std::cerr << "nz = " << nz << std::endl;
+
     uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
     uxstream.close();

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -292,7 +292,7 @@ void spg::write_l1_weights( )
 {
     std::ofstream wstream;
 
-    float* w_rec = new float[npix * npix * nframes];
+    float* w_rec = new float[npix * npix * nframes * nz];
 
     checkCudaErrors( cudaMemcpy2D(
             w_rec, npix * npix * nframes * sizeof(float),
@@ -302,8 +302,10 @@ void spg::write_l1_weights( )
             ) );
 
     wstream.open("w.dat", std::fstream::out | std::fstream::trunc | std::fstream::binary);
-    wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes);
+    wstream.write(reinterpret_cast<char *> (w_rec), sizeof(float) * npix * npix * nframes * nz);
     wstream.close();
+
+    delete[] w_rec;
 }
 
 void spg::write_pos_data(char* suffix)
@@ -392,5 +394,8 @@ void spg::write_l1_data(char* suffix)
     l1stream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     l1stream.write(reinterpret_cast<char *> (u_rec), buffer_bytes);
     l1stream.close( );
+
+    delete[] alpha_rec;
+    delete[] u_rec;
 
 }

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -297,14 +297,23 @@ void spg::write_u_x(char* suffix)
 
     uxstream.exceptions( std::ofstream::eofbit | std::ofstream::failbit | std::ofstream::badbit );
 
+    std::cerr << "Opening file" << std::endl;
+
     uxstream.open(uname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
+
+    std::cerr << "Opened file, commencing write" << std::endl;
+
     try {
         uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), u_buffer_bytes);
     } catch (std::ofstream::failure e) {
         std::cerr << "Exception writing to u file: " << e.what() << std::endl;
     }
+
+    std::cerr << "Wrote data, closing file" << std::endl;
 //    uxstream.flush();
     uxstream.close();
+
+
 
     uxstream.open(xname, std::fstream::out | std::fstream::trunc | std::fstream::binary);
     try {

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -137,7 +137,7 @@ spg::~spg()
     free ( pp );
 }
 
-void spg::prox_pos ( float *delta, int niter )
+void spg::prox_pos ( float *delta, int niter, bool do_output )
 {
     sdkResetTimer ( &timer );
     sdkStartTimer ( &timer );
@@ -176,7 +176,7 @@ void spg::prox_pos ( float *delta, int niter )
     std::cout << "Time spent for solving positivity spg " <<  sdkGetTimerValue ( &timer ) << std::endl;
 }
 
-void spg::prox_l1 ( float *alpha, int niter )
+void spg::prox_l1 ( float *alpha, int niter, bool do_output )
 {
     sdkResetTimer ( &timer );
     sdkStartTimer ( &timer );

--- a/src/spg.cpp
+++ b/src/spg.cpp
@@ -281,10 +281,12 @@ void spg::write_u_x(char* suffix)
 
     uxstream.open(std::string("u").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_u_pos[0]), sizeof(float) * coeff_stride_pos[0] * nz);
+    uxstream.flush();
     uxstream.close();
 
     uxstream.open(std::string("x").append(suffix).append(".dat"), std::fstream::out | std::fstream::trunc | std::fstream::binary);
     uxstream.write(reinterpret_cast<char *> (d_x[0]), sizeof(float) * coeff_stride[0] * nz);
+    uxstream.flush();
     uxstream.close();
 
 }

--- a/src/spg.h
+++ b/src/spg.h
@@ -95,7 +95,7 @@ public:
 private:
     void write_config_file();
     void write_p_pp();
-    void write_u_x(char* suffix);
+    void write_pos_data(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -94,6 +94,9 @@ public:
     void inject_u_pos(float *h_u_pos);
     void extract_u_pos(float *h_u_pos);
 
+    void inject_u(float *h_u);
+    void extract_u(float *h_u);
+
 private:
     void write_config_file();
     void write_p_pp();

--- a/src/spg.h
+++ b/src/spg.h
@@ -91,6 +91,11 @@ public:
      */
     void update_weights(float *l1_weights);
     
+
+private:
+    void write_config_file();
+    void write_p_pp();
+    void write_u_x(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -99,8 +99,8 @@ public:
 
 private:
     void write_config_file();
-    void write_p_pp();
-    void write_l1_weights();
+    void write_p_pp(char* suffix);
+    void write_l1_weights(char* suffix);
     void write_pos_data(char* suffix);
     void write_l1_data(char* suffix);
 };

--- a/src/spg.h
+++ b/src/spg.h
@@ -78,13 +78,13 @@ public:
     /* Compute the proximity operator of the sparsity constraint.
      * 
      */
-    void prox_l1(float *alpha, int niter=10000);
+    void prox_l1(float *alpha, int niter=10000, bool do_output=false);
 
 
     /* Compute the proximity operator of the positivity constraint.
      *
      */
-    void prox_pos(float *delta, int niter=10000);
+    void prox_pos(float *delta, int niter=10000, bool do_output=false);
     
     /* Updates the l1 thresholds
      * 

--- a/src/spg.h
+++ b/src/spg.h
@@ -95,7 +95,9 @@ public:
 private:
     void write_config_file();
     void write_p_pp();
+    void write_l1_weights();
     void write_pos_data(char* suffix);
+    void write_l1_data(char* suffix);
 };
 
 

--- a/src/spg.h
+++ b/src/spg.h
@@ -91,6 +91,8 @@ public:
      */
     void update_weights(float *l1_weights);
     
+    void inject_u_pos(float *h_u_pos);
+    void extract_u_pos(float *h_u_pos);
 
 private:
     void write_config_file();


### PR DESCRIPTION
 A branch to use the data captured in the `datacapture` branch. Modified to read in the independent variables and internal state files, and to run a single step of the iteration on a single GPU. Dumps files in the same format as `datacapture`.

- `*_w.dat` contains the values of the arrays before the CUDA code. These files provide a sanity check, and should always be identical to the `datacapture` `*_i.dat` files.
- `*_c.dat` contains the values of the arrays after the CUDA code. If everything is working correctly, these will have the same values as the `datacapture` `*_o.dat` files. Testing whether they do or not is to test whether the kernels are functioning correctly.