### PR TITLE
Mainbreakup

### DIFF
--- a/src/glimpse.cpp
+++ b/src/glimpse.cpp
@@ -36,10 +36,10 @@
 #include <iostream>
 #include <fstream>
 #include <CCfits/CCfits>
-#include <boost/property_tree/ptree.hpp>
 #include <boost/property_tree/ini_parser.hpp>
-#include <boost/program_options.hpp>
 #include <boost/algorithm/string.hpp>
+
+#include "glimpse.h"
 
 #include "version.h"
 #include "survey.h"
@@ -48,13 +48,9 @@
 #include "density_reconstruction.h"
 #include "gpu_utils.h"
 
-
-namespace po = boost::program_options;
 using namespace std;
 using namespace CCfits;
 
-void create_config(int argc, char *argv[], boost::property_tree::ptree &pt, po::variables_map &vm);
-int configure_and_run(boost::property_tree::ptree &pt, po::variables_map &vm);
 
 int main(int argc, char *argv[])
 {

--- a/src/glimpse.h
+++ b/src/glimpse.h
@@ -1,0 +1,46 @@
+/* Copyright UCL, 2019
+ * author Timothy Spain < t.spain@ucl.ac.uk >
+ *
+ * This software is a computer program whose purpose is to reconstruct mass maps
+ * from weak gravitational lensing.
+ *
+ * This software is governed by the CeCILL license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ * knowledge of the CeCILL license and that you accept its terms.
+ *
+ */
+
+#ifndef GLIMPSE_H
+#define GLIMPSE_H
+
+#include <boost/program_options.hpp>
+#include <boost/property_tree/ptree.hpp>
+
+namespace po = boost::program_options;
+
+void create_config(int argc, char *argv[], boost::property_tree::ptree &pt, po::variables_map &vm);
+int configure_and_run(boost::property_tree::ptree &pt, po::variables_map &vm);
+
+#endif // ndef GLIMPSE_H

--- a/src/glimpse.h
+++ b/src/glimpse.h
@@ -40,7 +40,7 @@
 
 namespace po = boost::program_options;
 
-void create_config(int argc, char *argv[], boost::property_tree::ptree &pt, po::variables_map &vm);
+int create_config(int argc, char *argv[], boost::property_tree::ptree &pt, po::variables_map &vm);
 int configure_and_run(boost::property_tree::ptree &pt, po::variables_map &vm);
 
 #endif // ndef GLIMPSE_H


### PR DESCRIPTION
Why?
For testing. Tests can compile their own `pt` and `vm` configuration variables, either programatically or by reading their own config files (and can use `create_config()` to do so). Glimpse can then be configured and run using this configuration.

This PR allows glimpse to be run programatically.