### PR TITLE
Move the RNG initialization

### DIFF
--- a/src/glimpse.cpp
+++ b/src/glimpse.cpp
@@ -63,9 +63,7 @@ const int return_fitsio_err = -1;
 
 int main(int argc, char *argv[])
 {
-    gsl_rng_env_setup();
     boost::property_tree::ptree pt;
-    
     po::variables_map vm;
 
     switch (create_config(argc, argv, pt, vm)) {
@@ -199,6 +197,8 @@ int create_config(int argc, char *argv[], boost::property_tree::ptree &pt, po::v
 
 int configure_and_run(boost::property_tree::ptree &pt, po::variables_map &vm)
 {
+    gsl_rng_env_setup();
+
     // Create survey object and load data
     survey *surv = new survey(pt);
     surv->load(vm["data"].as<std::string>());


### PR DESCRIPTION
The GSL RNG initialization should probablt be run even if we don't call Glimpse through its `main()` function. Nothing in `create_config()` seems to depend on random number generation, so moving the call to `configure_and_run()` should be safe.